### PR TITLE
malloc fix to enable compilation with g++

### DIFF
--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -69,7 +69,7 @@ static char * xstrdup(char * s)
     char * t ;
     if (!s)
         return NULL ;
-    t = malloc(strlen(s)+1) ;
+    t = (char*)malloc(strlen(s)+1) ;
     if (t) {
         strcpy(t,s);
     }


### PR DESCRIPTION
g++ returns an error when a non-void pointer is set to be the return
value from malloc.
