### PR TITLE
Fix for falsely diagnosed buffer overflow when EOF without newline is re...

### DIFF
--- a/src/iniparser.c
+++ b/src/iniparser.c
@@ -666,7 +666,7 @@ dictionary * iniparser_load(const char * ininame)
         if (len==0)
             continue;
         /* Safety check against buffer overflows */
-        if (line[len]!='\n') {
+        if (line[len]!='\n' && !feof(in)) {
             fprintf(stderr,
                     "iniparser: input line too long in %s (%d)\n",
                     ininame,


### PR DESCRIPTION
If there is no \n at the end of the file, iniparser detects that as buffer overflow. A call to check for EOF fixes this
