### PR TITLE
Fix compilation with Visual Studio

### DIFF
--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -18,7 +18,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 /** Maximum value size for integers and doubles. */
 #define MAXVALSZ    1024

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -21,7 +21,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 /*---------------------------------------------------------------------------
                                 New types


### PR DESCRIPTION
Visual Studio does not have 'unistd.h', so exclude it when compiling on Windows.
It also seems to not be necessary on OS X (tested on 10.8). If no symbols from 'unistd.h' are used it would be better to completely remove it.
