### PR TITLE
Prevent compiler warning when compiling for 64 bit

### DIFF
--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -35,7 +35,7 @@
 
 /* Doubles the allocated size associated to a pointer */
 /* 'size' is the current allocated size. */
-static void * mem_double(void * ptr, int size)
+static void * mem_double(void * ptr, size_t size)
 {
     void * newptr ;
  
@@ -87,11 +87,11 @@ static char * xstrdup(const char * s)
 /*--------------------------------------------------------------------------*/
 unsigned dictionary_hash(const char * key)
 {
-    int         len ;
+    size_t      len ;
     unsigned    hash ;
-    int         i ;
+    size_t      i ;
 
-    len = (int)strlen(key);
+    len = strlen(key);
     for (hash=0, i=0 ; i<len ; i++) {
         hash += (unsigned)key[i] ;
         hash += (hash<<10);
@@ -249,9 +249,9 @@ int dictionary_set(dictionary * d, const char * key, const char * val)
     if (d->n==d->size) {
 
         /* Reached maximum size: reallocate dictionary */
-        d->val  = (char **)mem_double(d->val,  d->size * (int)sizeof(char*)) ;
-        d->key  = (char **)mem_double(d->key,  d->size * (int)sizeof(char*)) ;
-        d->hash = (unsigned int *)mem_double(d->hash, d->size * (int)sizeof(unsigned)) ;
+        d->val  = (char **)mem_double(d->val,  d->size * sizeof(char*)) ;
+        d->key  = (char **)mem_double(d->key,  d->size * sizeof(char*)) ;
+        d->hash = (unsigned int *)mem_double(d->hash, d->size * sizeof(unsigned)) ;
         if ((d->val==NULL) || (d->key==NULL) || (d->hash==NULL)) {
             /* Cannot grow dictionary */
             return -1 ;


### PR DESCRIPTION
When compiling for 64 bit size_t is a 64 bit data type but int is usually 32 bit.
Do the proper casts to avoid compiler warnings.
