### PR TITLE
Makefile fixes: Library build, targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ OBJS = $(SRCS:.c=.o)
 default:	libiniparser.a libiniparser.so
 
 libiniparser.a:	$(OBJS)
-	$(QUIET_AR)$(AR) $(ARFLAGS) $@ $<
+	$(QUIET_AR)$(AR) $(ARFLAGS) $@ $^
 	$(QUIET_RANLIB)$(RANLIB) $@
 
 libiniparser.so:	$(OBJS)
@@ -66,5 +66,7 @@ veryclean:
 docs:
 	@(cd doc ; $(MAKE))
 	
-check:
+check: default
 	@(cd test ; $(MAKE))
+
+.PHONY: default clean veryclean docs check


### PR DESCRIPTION
This fixes #32 so that the static library builds correctly:

Changed the build command for the static library to include all objects
and added .PHONY for the targets that do not create files of the same
name.

Also, sorry about the other pull request, accidentally used my master branch as target. D'oh.
