### PR TITLE
Fix crash with crafted ini files.

### DIFF
--- a/src/iniparser.c
+++ b/src/iniparser.c
@@ -633,7 +633,7 @@ dictionary * iniparser_load(const char * ininame)
     char line    [ASCIILINESZ+1] ;
     char section [ASCIILINESZ+1] ;
     char key     [ASCIILINESZ+1] ;
-    char tmp     [ASCIILINESZ+1] ;
+    char tmp     [(ASCIILINESZ * 2) + 1] ;
     char val     [ASCIILINESZ+1] ;
 
     int  last=0 ;
@@ -699,7 +699,7 @@ dictionary * iniparser_load(const char * ininame)
             break ;
 
             case LINE_VALUE:
-            sprintf(tmp, "%s:%s", section, key);
+            snprintf(tmp, sizeof(tmp), "%s:%s", section, key);
             errs = dictionary_set(dict, tmp, val) ;
             break ;
 


### PR DESCRIPTION
If the key or value is bigger than 1024 we will end up in a buffer
overflow. The overflow is caught by _FORTIFY_SOURCE, so it's definitely
DoS-only.  Curiously, because of ample space in the stack frame, it does
not result in a crash without _FORTIFY_SOURCE in all cases.
