### PR TITLE
modify iniparser to build unbounded keys & values from multi-line input

### DIFF
--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -58,7 +58,7 @@ static void * mem_double(void * ptr, size_t size)
   for systems that do not have it.
  */
 /*--------------------------------------------------------------------------*/
-static char * xstrdup(const char * s)
+char * xstrdup(const char * s)
 {
     char * t ;
     size_t len ;

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -166,6 +166,18 @@ void dictionary_unset(dictionary * d, const char * key);
 /*--------------------------------------------------------------------------*/
 void dictionary_dump(dictionary * d, FILE * out);
 
+/*-------------------------------------------------------------------------*/
+/**
+  @brief    Duplicate a string
+  @param    s String to duplicate
+  @return   Pointer to a newly allocated string, to be freed with free()
+
+  This is a replacement for strdup(). This implementation is provided
+  for systems that do not have it.
+ */
+/*--------------------------------------------------------------------------*/
+char * xstrdup(const char * s);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Instead of a size limit of ASCIILINESZ for multi-line input now there is no
limit, a multi-line can be _any_ size (and hence the key and value now
also have a dynamic size)
- there is a limit still on input line size (since multi lines are built
  from multiple lines where each line part is limited to ASCIILINESZ)
  Note: there is no limit to the size of the multi-line itself (it's
  only limited by available memory)
- all stack & static fixed string usage has been removed with the exception
  of parsing line (or a multi-line portion) input, fgets still reads into
  a fixed string buffer of size ASCIILINESZ.

Signed-off-by: Noel Power noel.power@suse.com
