### PR TITLE
Prevent negative array index access when a line solely consists of newlines and spaces

### DIFF
--- a/src/iniparser.c
+++ b/src/iniparser.c
@@ -752,6 +752,10 @@ dictionary * iniparser_load(const char * ininame)
             len-- ;
         }
 
+        if (len < 0) { /* Line was entirely \n and/or spaces */
+            len = 0;
+        }
+
         /* Detect multi-line */
         if (line[len]=='\\') {
             multi_line = 1;


### PR DESCRIPTION
`len` can get decremented to -1 if the line is purely newlines and spaces.  Prevent negative array indices by resetting length to zero if it got decremented to -1.
