### PR TITLE
test_dictionary: fix warning/error when compiling with -O1 or higher

### DIFF
--- a/test/test_dictionary.c
+++ b/test/test_dictionary.c
@@ -122,7 +122,12 @@ static char *get_dump(dictionary *d)
         fclose(fd);
         return NULL;
     }
-    fread(dump_buff, 1, dump_size, fd);
+    /*
+     * Assignment to dump_size is not necessarry, but when compiling with -O1 or
+     * higher and combined with -Wall, it produces the 'ignoring return value'
+     * error.
+     */
+    dump_size = fread(dump_buff, 1, dump_size, fd);
 
     fclose(fd);
     return dump_buff;


### PR DESCRIPTION
I build the whole iniparser with -O2 -Wall options. This is the only error that pops out, in test suite.
The rest of commit message follows below.

----------------------------------------------------------------------------------------------

If test suite is built with -01 or higher, and combined with -Wall,
it produces the following error:

test_dictionary.c: In function ‘get_dump’:
test_dictionary.c:131:10: warning: ignoring return value of ‘fread’, declared with attribute warn_unused_result [-Wunused-result]
     fread(dump_buff, 1, dump_size, fd);
          ^

The workaround is to assign return value to dump_size. The value returned by
fread() should be equal to original dump_size, unless an error occured. As
dump_size is not used after that call, it matters not whether check for error
is performed or not, thus it is skipped.