### PR TITLE
Declare strstrip for picky compilers

### DIFF
--- a/src/iniparser.c
+++ b/src/iniparser.c
@@ -29,6 +29,11 @@ typedef enum _line_status_ {
     LINE_VALUE
 } line_status ;
 
+/**
+ * For picky compilers/flags.
+ */
+unsigned strstrip(char * s);
+
 /*-------------------------------------------------------------------------*/
 /**
   @brief    Convert a string to lowercase.


### PR DESCRIPTION
Hi,

Here's a trivial patch needed for really picky compiler flags (i.e. mine :-) ).