### PR TITLE
Add fd passing to iniparser_load

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # Compiler settings
 CC      ?= gcc
 
-CFLAGS  += -fPIC -Wall -Wextra -ansi -pedantic
+CFLAGS  += -fPIC -Wall -Wextra -ansi -pedantic -std=gnu99
 ifndef DEBUG
 ADDITIONAL_CFLAGS  ?= -O2
 else

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # Compiler settings
 CC      ?= gcc
 
-CFLAGS  += -fPIC -Wall -Wextra -ansi -pedantic -std=gnu99
+CFLAGS  += -fPIC -Wall -Wextra -pedantic
 ifndef DEBUG
 ADDITIONAL_CFLAGS  ?= -O2
 else

--- a/src/iniparser.c
+++ b/src/iniparser.c
@@ -8,7 +8,6 @@
 /*--------------------------------------------------------------------------*/
 /*---------------------------- Includes ------------------------------------*/
 #include <ctype.h>
-#include <stdio.h>
 #include "iniparser.h"
 
 /*---------------------------- Defines -------------------------------------*/
@@ -700,7 +699,7 @@ dictionary * iniparser_load_ini(const char * ininame, const int inifd)
 
     dict = dictionary_new(0) ;
     if (!dict) {
-        fclose(in); 
+        fclose(in);
         return NULL ;
     }
 
@@ -729,7 +728,7 @@ dictionary * iniparser_load_ini(const char * ininame, const int inifd)
                         lineno);
             }
             dictionary_del(dict);
-            fclose(in); 
+            fclose(in);
             return NULL ;
         }
         /* Get rid of \n and spaces at end of line */
@@ -791,7 +790,7 @@ dictionary * iniparser_load_ini(const char * ininame, const int inifd)
         dictionary_del(dict);
         dict = NULL ;
     }
-    fclose(in); 
+    fclose(in);
     return dict ;
 }
 

--- a/src/iniparser.c
+++ b/src/iniparser.c
@@ -666,7 +666,7 @@ static line_status iniparser_line(
   @brief    Parse an ini file and return an allocated dictionary object
   @param    ininame Name of the ini file to read or NULL if with fd.
   @param    inifd File descriptor of the ini file to read or -1 if with name.
-  @return   unsigned New size of the string.
+  @return   Pointer to newly allocated dictionary
  */
 /*--------------------------------------------------------------------------*/
 dictionary * iniparser_load_ini(const char * ininame, const int inifd)

--- a/src/iniparser.h
+++ b/src/iniparser.h
@@ -328,6 +328,21 @@ dictionary * iniparser_load(const char * ininame);
 
 /*-------------------------------------------------------------------------*/
 /**
+  @brief    Parse an ini file and return an allocated dictionary object
+  @param    inifd File descriptor of the ini file to read.
+  @return   Pointer to newly allocated dictionary
+
+  This is the parser for ini files. With the exception of taking
+  in a file descriptor instead of a name, this function is identially
+  to a iniparser_load.
+
+  The returned dictionary must be freed using iniparser_freedict().
+ */
+/*--------------------------------------------------------------------------*/
+dictionary * iniparser_load_fd(const int inifd);
+
+/*-------------------------------------------------------------------------*/
+/**
   @brief    Free all memory associated to an ini dictionary
   @param    d Dictionary to free
   @return   void

--- a/test/Makefile
+++ b/test/Makefile
@@ -11,7 +11,7 @@ SRC = $(shell ls *.c | sed 's/AllTests.c//')
 OBJ = $(SRC:.c=.o)
 
 INCLUDE = -I../src
-CFLAGS  += -pipe -ansi -pedantic -Wall -Wextra -g -std=gnu99
+CFLAGS  += -pipe -pedantic -Wall -Wextra -g
 LDFLAGS +=
 
 all: check

--- a/test/Makefile
+++ b/test/Makefile
@@ -11,7 +11,7 @@ SRC = $(shell ls *.c | sed 's/AllTests.c//')
 OBJ = $(SRC:.c=.o)
 
 INCLUDE = -I../src
-CFLAGS  += -pipe -ansi -pedantic -Wall -Wextra -g
+CFLAGS  += -pipe -ansi -pedantic -Wall -Wextra -g -std=gnu99
 LDFLAGS +=
 
 all: check

--- a/test/test_iniparser.c
+++ b/test/test_iniparser.c
@@ -3,6 +3,7 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <fcntl.h>
 
 #include "CuTest.h"
 #include "dictionary.h"
@@ -595,6 +596,7 @@ void Test_iniparser_load(CuTest *tc)
     struct stat curr_stat;
     dictionary *dic;
     char ini_path[256];
+    int ini_fd;
 
     /* Dummy tests */
     dic = iniparser_load("/you/shall/not/path");
@@ -610,6 +612,12 @@ void Test_iniparser_load(CuTest *tc)
             dic = iniparser_load(ini_path);
             CuAssertPtrNotNullMsg(tc, ini_path, dic);
             dictionary_del(dic);
+            /* Test inparser_load_fd */
+            ini_fd = open(ini_path, O_RDONLY);
+            dic = iniparser_load_fd(ini_fd);
+            CuAssertPtrNotNullMsg(tc, ini_path, dic);
+            dictionary_del(dic);
+            close(ini_fd);
         }
     }
     closedir(dir);
@@ -624,6 +632,12 @@ void Test_iniparser_load(CuTest *tc)
             dic = iniparser_load(ini_path);
             CuAssertPtrEquals_Msg(tc, ini_path, NULL, dic);
             dictionary_del(dic);
+            /* Test inparser_load_fd */
+            ini_fd = open(ini_path, O_RDONLY);
+            dic = iniparser_load_fd(ini_fd);
+            CuAssertPtrEquals_Msg(tc, ini_path, NULL, dic);
+            dictionary_del(dic);
+            close(ini_fd);
         }
     }
     closedir(dir);


### PR DESCRIPTION
-added iniparser_load_fd function which has same functionality as iniparser_load except uses an fd instead of 
-iniparser_load call remains the same externally
-slighty refactored iniparser load to support fds and filenames with little additional code
-could be very benefical 
-added test for iniparser_load_fd
-new and existing test pass 
-added flags to makefile to support fdopen