### PR TITLE
remove unnecessary condition

### DIFF
--- a/src/iniparser.c
+++ b/src/iniparser.c
@@ -762,8 +762,7 @@ dictionary * iniparser_load(const char * ininame)
             return NULL ;
         }
         /* Get rid of \n and spaces at end of line */
-        while ((len>=0) &&
-                ((line[len]=='\n') || (isspace(line[len])))) {
+        while ((len>=0) && (isspace(line[len]))) {
             line[len]=0 ;
             len-- ;
         }


### PR DESCRIPTION
isspace()
              checks for white-space characters.  In the "C" and "POSIX" locales, these are: space, form-feed ('\f'), newline ('\n'), carriage return ('\r'), horizontal tab ('\t'), and vertical tab ('\v').