### PR TITLE
ssize_t isn't defined in ANSI C89

### DIFF
--- a/FAQ-en.md
+++ b/FAQ-en.md
@@ -35,3 +35,10 @@ See the docs: iniparser is a C library. C++ is quite a different language,
 despite the promises of compatibility. You will have to modify iniparser
 quite heavily to make it work with a C++ compiler. Good luck!
 
+## iniparser uses unistd.h, which is absent on Windows!
+
+iniparser uses ssize_t type as part of its public interface. Since adding
+special #ifdef _WIN32 checks would damage the maintainability of the code,
+special unistd.h with just the ssize_t definition is provided in src/win32
+directory. You can either add it to the include path or just comment out the
+offending line and typedef your own ssize_t instead.

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -175,7 +175,7 @@ dictionary * dictionary_new(size_t size)
 /*--------------------------------------------------------------------------*/
 void dictionary_del(dictionary * d)
 {
-    size_t  i ;
+    int  i ;
 
     if (d==NULL) return ;
     for (i=0 ; i<d->size ; i++) {
@@ -208,7 +208,7 @@ void dictionary_del(dictionary * d)
 const char * dictionary_get(const dictionary * d, const char * key, const char * def)
 {
     unsigned    hash ;
-    size_t      i ;
+    int         i ;
 
     hash = dictionary_hash(key);
     for (i=0 ; i<d->size ; i++) {
@@ -253,7 +253,7 @@ const char * dictionary_get(const dictionary * d, const char * key, const char *
 /*--------------------------------------------------------------------------*/
 int dictionary_set(dictionary * d, const char * key, const char * val)
 {
-    size_t         i ;
+    int            i ;
     unsigned       hash ;
 
     if (d==NULL || key==NULL) return -1 ;
@@ -313,7 +313,7 @@ int dictionary_set(dictionary * d, const char * key, const char * val)
 void dictionary_unset(dictionary * d, const char * key)
 {
     unsigned    hash ;
-    size_t      i ;
+    int         i ;
 
     if (key == NULL || d == NULL) {
         return;
@@ -361,7 +361,7 @@ void dictionary_unset(dictionary * d, const char * key)
 /*--------------------------------------------------------------------------*/
 void dictionary_dump(const dictionary * d, FILE * out)
 {
-    size_t  i ;
+    int  i ;
 
     if (d==NULL || out==NULL) return ;
     if (d->n<1) {

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -175,7 +175,7 @@ dictionary * dictionary_new(size_t size)
 /*--------------------------------------------------------------------------*/
 void dictionary_del(dictionary * d)
 {
-    int  i ;
+    ssize_t  i ;
 
     if (d==NULL) return ;
     for (i=0 ; i<d->size ; i++) {
@@ -208,7 +208,7 @@ void dictionary_del(dictionary * d)
 const char * dictionary_get(const dictionary * d, const char * key, const char * def)
 {
     unsigned    hash ;
-    int         i ;
+    ssize_t        i ;
 
     hash = dictionary_hash(key);
     for (i=0 ; i<d->size ; i++) {
@@ -253,7 +253,7 @@ const char * dictionary_get(const dictionary * d, const char * key, const char *
 /*--------------------------------------------------------------------------*/
 int dictionary_set(dictionary * d, const char * key, const char * val)
 {
-    int            i ;
+    ssize_t           i ;
     unsigned       hash ;
 
     if (d==NULL || key==NULL) return -1 ;
@@ -313,7 +313,7 @@ int dictionary_set(dictionary * d, const char * key, const char * val)
 void dictionary_unset(dictionary * d, const char * key)
 {
     unsigned    hash ;
-    int         i ;
+    ssize_t        i ;
 
     if (key == NULL || d == NULL) {
         return;
@@ -361,7 +361,7 @@ void dictionary_unset(dictionary * d, const char * key)
 /*--------------------------------------------------------------------------*/
 void dictionary_dump(const dictionary * d, FILE * out)
 {
-    int  i ;
+    ssize_t  i ;
 
     if (d==NULL || out==NULL) return ;
     if (d->n<1) {

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -208,7 +208,7 @@ void dictionary_del(dictionary * d)
 const char * dictionary_get(const dictionary * d, const char * key, const char * def)
 {
     unsigned    hash ;
-    ssize_t        i ;
+    ssize_t      i ;
 
     hash = dictionary_hash(key);
     for (i=0 ; i<d->size ; i++) {
@@ -253,7 +253,7 @@ const char * dictionary_get(const dictionary * d, const char * key, const char *
 /*--------------------------------------------------------------------------*/
 int dictionary_set(dictionary * d, const char * key, const char * val)
 {
-    ssize_t           i ;
+    ssize_t         i ;
     unsigned       hash ;
 
     if (d==NULL || key==NULL) return -1 ;
@@ -313,7 +313,7 @@ int dictionary_set(dictionary * d, const char * key, const char * val)
 void dictionary_unset(dictionary * d, const char * key)
 {
     unsigned    hash ;
-    ssize_t        i ;
+    ssize_t      i ;
 
     if (key == NULL || d == NULL) {
         return;

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -18,7 +18,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 /** Maximum value size for integers and doubles. */
 #define MAXVALSZ    1024
@@ -176,7 +175,7 @@ dictionary * dictionary_new(size_t size)
 /*--------------------------------------------------------------------------*/
 void dictionary_del(dictionary * d)
 {
-    ssize_t  i ;
+    size_t  i ;
 
     if (d==NULL) return ;
     for (i=0 ; i<d->size ; i++) {
@@ -209,7 +208,7 @@ void dictionary_del(dictionary * d)
 const char * dictionary_get(const dictionary * d, const char * key, const char * def)
 {
     unsigned    hash ;
-    ssize_t      i ;
+    size_t      i ;
 
     hash = dictionary_hash(key);
     for (i=0 ; i<d->size ; i++) {
@@ -254,7 +253,7 @@ const char * dictionary_get(const dictionary * d, const char * key, const char *
 /*--------------------------------------------------------------------------*/
 int dictionary_set(dictionary * d, const char * key, const char * val)
 {
-    ssize_t         i ;
+    size_t         i ;
     unsigned       hash ;
 
     if (d==NULL || key==NULL) return -1 ;
@@ -314,7 +313,7 @@ int dictionary_set(dictionary * d, const char * key, const char * val)
 void dictionary_unset(dictionary * d, const char * key)
 {
     unsigned    hash ;
-    ssize_t      i ;
+    size_t      i ;
 
     if (key == NULL || d == NULL) {
         return;
@@ -362,7 +361,7 @@ void dictionary_unset(dictionary * d, const char * key)
 /*--------------------------------------------------------------------------*/
 void dictionary_dump(const dictionary * d, FILE * out)
 {
-    ssize_t  i ;
+    size_t  i ;
 
     if (d==NULL || out==NULL) return ;
     if (d->n<1) {

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -21,7 +21,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#ifndef _WIN32
+#ifdef _WIN32
+	/* long int is the longest signed integer in standard C89 */
+	typedef long int ssize_t;
+#else
 	#include <unistd.h>
 #endif
 
@@ -46,11 +49,7 @@ extern "C" {
 /*-------------------------------------------------------------------------*/
 typedef struct _dictionary_ {
     int               n ;   /** Number of entries in dictionary */
-#ifdef _WIN32
-    int            size ;
-#else
     ssize_t        size ;   /** Storage size */
-#endif
     char        **  val ;   /** List of string values */
     char        **  key ;   /** List of string keys */
     unsigned     *  hash ;  /** List of hash values for keys */

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -21,7 +21,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -43,8 +42,8 @@ extern "C" {
  */
 /*-------------------------------------------------------------------------*/
 typedef struct _dictionary_ {
-    int             n ;     /** Number of entries in dictionary */
-    ssize_t         size ;  /** Storage size */
+    size_t            n ;     /** Number of entries in dictionary */
+    size_t         size ;  /** Storage size */
     char        **  val ;   /** List of string values */
     char        **  key ;   /** List of string keys */
     unsigned     *  hash ;  /** List of hash values for keys */

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -21,6 +21,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef _WIN32
+	#include <unistd.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -42,8 +45,12 @@ extern "C" {
  */
 /*-------------------------------------------------------------------------*/
 typedef struct _dictionary_ {
-    size_t            n ;     /** Number of entries in dictionary */
-    size_t         size ;  /** Storage size */
+    int               n ;   /** Number of entries in dictionary */
+#ifdef _WIN32
+    int            size ;
+#else
+    ssize_t        size ;   /** Storage size */
+#endif
     char        **  val ;   /** List of string values */
     char        **  key ;   /** List of string keys */
     unsigned     *  hash ;  /** List of hash values for keys */

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -48,8 +48,8 @@ extern "C" {
  */
 /*-------------------------------------------------------------------------*/
 typedef struct _dictionary_ {
-    int               n ;   /** Number of entries in dictionary */
-    ssize_t        size ;   /** Storage size */
+    int             n ;     /** Number of entries in dictionary */
+    ssize_t         size ;  /** Storage size */
     char        **  val ;   /** List of string values */
     char        **  key ;   /** List of string keys */
     unsigned     *  hash ;  /** List of hash values for keys */

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -21,12 +21,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#ifdef _WIN32
-	/* long int is the longest signed integer in standard C89 */
-	typedef long int ssize_t;
-#else
-	#include <unistd.h>
-#endif
+/*
+  On WIN32, add src/win32 to the include path or comment this out and
+  typedef your own ssize_t.
+*/
+#include <unistd.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/iniparser.c
+++ b/src/iniparser.c
@@ -163,7 +163,7 @@ void iniparser_set_error_callback(int (*errback)(const char *, ...))
 /*--------------------------------------------------------------------------*/
 int iniparser_getnsec(const dictionary * d)
 {
-    size_t i ;
+    int i ;
     int nsec ;
 
     if (d==NULL) return -1 ;
@@ -194,7 +194,7 @@ int iniparser_getnsec(const dictionary * d)
 /*--------------------------------------------------------------------------*/
 const char * iniparser_getsecname(const dictionary * d, int n)
 {
-    size_t i ;
+    int i ;
     int foundsec ;
 
     if (d==NULL || n<0) return NULL ;
@@ -229,7 +229,7 @@ const char * iniparser_getsecname(const dictionary * d, int n)
 /*--------------------------------------------------------------------------*/
 void iniparser_dump(const dictionary * d, FILE * f)
 {
-    size_t     i ;
+    int     i ;
 
     if (d==NULL || f==NULL) return ;
     for (i=0 ; i<d->size ; i++) {
@@ -257,7 +257,7 @@ void iniparser_dump(const dictionary * d, FILE * f)
 /*--------------------------------------------------------------------------*/
 void iniparser_dump_ini(const dictionary * d, FILE * f)
 {
-    size_t          i ;
+    int          i ;
     int          nsec ;
     const char * secname ;
 
@@ -273,8 +273,7 @@ void iniparser_dump_ini(const dictionary * d, FILE * f)
         }
         return ;
     }
-    /* int i>=1 and is therefore castable to size_t */
-    for (i=0 ; i<(size_t)nsec ; i++) {
+    for (i=0 ; i<nsec ; i++) {
         secname = iniparser_getsecname(d, i) ;
         iniparser_dumpsection_ini(d, secname, f);
     }
@@ -296,7 +295,7 @@ void iniparser_dump_ini(const dictionary * d, FILE * f)
 /*--------------------------------------------------------------------------*/
 void iniparser_dumpsection_ini(const dictionary * d, const char * s, FILE * f)
 {
-    size_t     j ;
+    int     j ;
     char    keym[ASCIILINESZ+1];
     int     seclen ;
 
@@ -332,7 +331,7 @@ int iniparser_getsecnkeys(const dictionary * d, const char * s)
 {
     int     seclen, nkeys ;
     char    keym[ASCIILINESZ+1];
-    size_t j ;
+    int j ;
 
     nkeys = 0;
 
@@ -372,7 +371,7 @@ int iniparser_getsecnkeys(const dictionary * d, const char * s)
 /*--------------------------------------------------------------------------*/
 const char ** iniparser_getseckeys(const dictionary * d, const char * s, const char ** keys)
 {
-    size_t i, j, seclen ;
+    int i, j, seclen ;
     char keym[ASCIILINESZ+1];
 
     if (d==NULL || keys==NULL) return NULL;

--- a/src/iniparser.c
+++ b/src/iniparser.c
@@ -163,7 +163,7 @@ void iniparser_set_error_callback(int (*errback)(const char *, ...))
 /*--------------------------------------------------------------------------*/
 int iniparser_getnsec(const dictionary * d)
 {
-    int i ;
+    size_t i ;
     int nsec ;
 
     if (d==NULL) return -1 ;
@@ -194,7 +194,7 @@ int iniparser_getnsec(const dictionary * d)
 /*--------------------------------------------------------------------------*/
 const char * iniparser_getsecname(const dictionary * d, int n)
 {
-    int i ;
+    size_t i ;
     int foundsec ;
 
     if (d==NULL || n<0) return NULL ;
@@ -229,7 +229,7 @@ const char * iniparser_getsecname(const dictionary * d, int n)
 /*--------------------------------------------------------------------------*/
 void iniparser_dump(const dictionary * d, FILE * f)
 {
-    int     i ;
+    size_t     i ;
 
     if (d==NULL || f==NULL) return ;
     for (i=0 ; i<d->size ; i++) {
@@ -257,7 +257,7 @@ void iniparser_dump(const dictionary * d, FILE * f)
 /*--------------------------------------------------------------------------*/
 void iniparser_dump_ini(const dictionary * d, FILE * f)
 {
-    int          i ;
+    size_t          i ;
     int          nsec ;
     const char * secname ;
 
@@ -273,7 +273,8 @@ void iniparser_dump_ini(const dictionary * d, FILE * f)
         }
         return ;
     }
-    for (i=0 ; i<nsec ; i++) {
+    /* int i>=1 and is therefore castable to size_t */
+    for (i=0 ; i<(size_t)nsec ; i++) {
         secname = iniparser_getsecname(d, i) ;
         iniparser_dumpsection_ini(d, secname, f);
     }
@@ -295,7 +296,7 @@ void iniparser_dump_ini(const dictionary * d, FILE * f)
 /*--------------------------------------------------------------------------*/
 void iniparser_dumpsection_ini(const dictionary * d, const char * s, FILE * f)
 {
-    int     j ;
+    size_t     j ;
     char    keym[ASCIILINESZ+1];
     int     seclen ;
 
@@ -331,7 +332,7 @@ int iniparser_getsecnkeys(const dictionary * d, const char * s)
 {
     int     seclen, nkeys ;
     char    keym[ASCIILINESZ+1];
-    int j ;
+    size_t j ;
 
     nkeys = 0;
 
@@ -371,7 +372,7 @@ int iniparser_getsecnkeys(const dictionary * d, const char * s)
 /*--------------------------------------------------------------------------*/
 const char ** iniparser_getseckeys(const dictionary * d, const char * s, const char ** keys)
 {
-    int i, j, seclen ;
+    size_t i, j, seclen ;
     char keym[ASCIILINESZ+1];
 
     if (d==NULL || keys==NULL) return NULL;

--- a/src/iniparser.h
+++ b/src/iniparser.h
@@ -18,13 +18,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-/*
- * The following #include is necessary on many Unixes but not Linux.
- * It is not needed for Windows platforms.
- * Uncomment it if needed.
- */
-/* #include <unistd.h> */
-
+/* Includes <unistd.h> on non-Windows */
 #include "dictionary.h"
 
 #ifdef __cplusplus

--- a/src/iniparser.h
+++ b/src/iniparser.h
@@ -18,7 +18,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* Includes <unistd.h> on non-Windows */
+/* Includes <unistd.h> or defines own ssize_t on Windows */
 #include "dictionary.h"
 
 #ifdef __cplusplus

--- a/src/win32/unistd.h
+++ b/src/win32/unistd.h
@@ -1,0 +1,5 @@
+/*
+  ssize_t is defined in POSIX and is absent in ANSI C89. To keep the public
+  interface intact, we have to define our own ssize_t on non-POSIX platforms.
+*/
+typedef int ssize_t;

--- a/test/test_dictionary.c
+++ b/test/test_dictionary.c
@@ -6,6 +6,7 @@
 /* We need to directly insert the .c file in order to test the */
 /* static functions as well */
 #include "dictionary.c"
+#include "iniparser.h"
 
 void Test_xstrdup(CuTest *tc)
 {
@@ -53,6 +54,7 @@ void Test_dictionary_grow(CuTest *tc)
         CuAssertIntEquals(tc, 0, dic->n);
         CuAssertIntEquals(tc, (1 << i) * DICTMINSZ, dic->size);
     }
+    iniparser_freedict(dic);
 }
 
 void Test_dictionary_hash(CuTest *tc)
@@ -184,6 +186,9 @@ void Test_dictionary_unset(CuTest *tc)
     CuAssertStrEquals(tc, dic1_dump, dic2_dump);
     free(dic1_dump);
     free(dic2_dump);
+
+    iniparser_freedict(dic1);
+    iniparser_freedict(dic2);
 }
 
 void Test_dictionary_dump(CuTest *tc)


### PR DESCRIPTION
Dear Maintainer,

I tried to build iniparser on MSVC, but failed, because there's no <unistd.h> on Windows. MSVC tries to conform to C89 (and parts of C99, C11); unistd.h is absent there because it's defined in POSIX, not ANSI C. I skimmed the source for places where the library code uses the ability of ssize_t to represent -1 and managed to replace all occurrences of ssize_t with size_t; the patch is attached.

All library tests still pass; I also verified memory accesses using valgrind. It seems that the replacement didn't introduce any leak or wrong memory access.