### PR TITLE
Add basic iniparser.pc

### DIFF
--- a/iniparser.pc
+++ b/iniparser.pc
@@ -1,0 +1,12 @@
+prefix=/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+datarootdir=${prefix}/share
+datadir=${datarootdir}
+
+Name: libiniparser
+Description: Iniparser library
+Version: 4.1
+Libs: -L${libdir} -liniparser
+Cflags: -I${includedir}


### PR DESCRIPTION
Hello,
it would be nice to have a basic iniparser.pc in the repository to be able to use iniparser in specific build systems (e.g. Buildroot). I know that this PR will not work for everyone, and that, according to FAQ, some proposals for more advanced integrations has already been rejected, so what is your opinion on the question (since this request would not change the main Makefile) ?