### PR TITLE
Cast characters to unsigned char before passed to isspace()

### DIFF
--- a/src/iniparser.c
+++ b/src/iniparser.c
@@ -96,9 +96,9 @@ static unsigned strstrip(char * s)
     if (s==NULL) return 0;
 
     last = s + strlen(s);
-    while (isspace((int)*s) && *s) s++;
+    while (isspace((unsigned char)*s) && *s) s++;
     while (last > s) {
-        if (!isspace((int)*(last-1)))
+        if (!isspace((unsigned char)*(last-1)))
             break ;
         last -- ;
     }
@@ -763,7 +763,7 @@ dictionary * iniparser_load(const char * ininame)
         }
         /* Get rid of \n and spaces at end of line */
         while ((len>=0) &&
-                ((line[len]=='\n') || (isspace(line[len])))) {
+                ((line[len]=='\n') || (isspace((unsigned char)line[len])))) {
             line[len]=0 ;
             len-- ;
         }


### PR DESCRIPTION
This would avoid sign extension.
Reason: The c argument is an int, the value of which the application
shall ensure is a character representable as an unsigned char or equal
to the value of the macro EOF. If the argument has any other value,
the behavior is undefined.
[man7.org] (http://man7.org/linux/man-pages/man3/isspace.3p.html)