### PR TITLE
Correct a memory leak problem

### DIFF
--- a/test/test_dictionary.c
+++ b/test/test_dictionary.c
@@ -184,6 +184,9 @@ void Test_dictionary_unset(CuTest *tc)
     CuAssertStrEquals(tc, dic1_dump, dic2_dump);
     free(dic1_dump);
     free(dic2_dump);
+
+    dictionary_del(dic1);
+    dictionary_del(dic2);
 }
 
 void Test_dictionary_dump(CuTest *tc)


### PR DESCRIPTION
Dear Maintainer,

I found that dictionary dic1 and dic2 was created in the begining of the function Test_dictionary_unset(), but it was kept  until the end of the function. I think this will cause a memory leak problem. So I made some changes to the code.