### PR TITLE
Support for loading string/custom streams

### DIFF
--- a/src/iniparser.h
+++ b/src/iniparser.h
@@ -338,6 +338,8 @@ int iniparser_find_entry(const dictionary * ini, const char * entry) ;
 /*--------------------------------------------------------------------------*/
 dictionary * iniparser_load(const char * ininame);
 
+dictionary * iniparser_load_file(FILE * in, const char * ininame);
+
 /*-------------------------------------------------------------------------*/
 /**
   @brief    Free all memory associated to an ini dictionary

--- a/src/iniparser.h
+++ b/src/iniparser.h
@@ -338,6 +338,20 @@ int iniparser_find_entry(const dictionary * ini, const char * entry) ;
 /*--------------------------------------------------------------------------*/
 dictionary * iniparser_load(const char * ininame);
 
+/*-------------------------------------------------------------------------*/
+/**
+  @brief    Parse an ini file and return an allocated dictionary object
+  @param    ininame File to read.
+  @param    ininame Name of the ini file to read (only used for nicer error messages)
+  @return   Pointer to newly allocated dictionary
+
+  This is the parser for ini files. This function is called, providing
+  the file to be read. It returns a dictionary object that should not 
+  be accessed directly, but through accessor functions instead.
+
+  The returned dictionary must be freed using iniparser_freedict().
+ */
+/*--------------------------------------------------------------------------*/
 dictionary * iniparser_load_file(FILE * in, const char * ininame);
 
 /*-------------------------------------------------------------------------*/


### PR DESCRIPTION
I added an `iniparser_load_file` function that takes a file pointer as a parameter to support loading [string/custom streams](https://www.gnu.org/software/libc/manual/html_node/String-Streams.html) as well as files. The function is essentially a copy of `iniparser_load` but without the creation of the file pointer. It also takes a filename as a parameter but it's only used for error messages. 
I also changed `iniparser_load` to reuse this function to avoid duplicating code.

I needed this for a personal project that uses iniparser and thought I'd contribute it if it's useful/wanted.