### PR TITLE
Handle potential calloc failures in dictionary_new.

### DIFF
--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -161,6 +161,13 @@ dictionary * dictionary_new(size_t size)
         d->val  = (char**) calloc(size, sizeof *d->val);
         d->key  = (char**) calloc(size, sizeof *d->key);
         d->hash = (unsigned*) calloc(size, sizeof *d->hash);
+        if (!d->size || !d->val || !d->hash) {
+            free((void *) d->size);
+            free((void *) d->val);
+            free((void *) d->hash);
+            free(d);
+            d = NULL;
+        }
     }
     return d ;
 }


### PR DESCRIPTION
Handle potential calloc failures in dictionary_new. In such case free all allocated resources and return NULL