### PR TITLE
docs: fix simple typo, objet -> object

### DIFF
--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -140,7 +140,7 @@ unsigned dictionary_hash(const char * key)
 /**
   @brief    Create a new dictionary object.
   @param    size    Optional initial size of the dictionary.
-  @return   1 newly allocated dictionary objet.
+  @return   1 newly allocated dictionary object.
 
   This function allocates a new dictionary object of given size and returns
   it. If you do not know in advance (roughly) the number of entries in the

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -73,7 +73,7 @@ unsigned dictionary_hash(const char * key);
 /**
   @brief    Create a new dictionary object.
   @param    size    Optional initial size of the dictionary.
-  @return   1 newly allocated dictionary objet.
+  @return   1 newly allocated dictionary object.
 
   This function allocates a new dictionary object of given size and returns
   it. If you do not know in advance (roughly) the number of entries in the


### PR DESCRIPTION
There is a small typo in src/dictionary.c, src/dictionary.h.

Should read `object` rather than `objet`.

