### PR TITLE
test/testiniparser.c: fix missing comma in token test list

### DIFF
--- a/test/test_iniparser.c
+++ b/test/test_iniparser.c
@@ -455,7 +455,7 @@ void Test_iniparser_getboolean(CuTest *tc)
         "T",
         "yes",
         "y",
-        "YES"
+        "YES",
         "Y",
         NULL
     };


### PR DESCRIPTION
Fix missing comma separating two test cases in the
Test_iniparser_getboolean() token_true list. Without this, the 'Y'
testcase was being skipped.

(Issue was found by coverity.)

Signed-off-by: Steve Beattie <steve.beattie@canonical.com>
Bug: https://github.com/ndevilla/iniparser/issues/131