### PR TITLE
Fix segfault on malformed config files

### DIFF
--- a/src/iniparser.c
+++ b/src/iniparser.c
@@ -421,7 +421,7 @@ const char * iniparser_getstring(const dictionary * d, const char * key, const c
 
     lc_key = strlwc(key, tmp_str, sizeof(tmp_str));
     sval = dictionary_get(d, lc_key, def);
-    return sval ;
+    return sval ? sval : def ;
 }
 
 /*-------------------------------------------------------------------------*/

--- a/src/iniparser.c
+++ b/src/iniparser.c
@@ -30,6 +30,8 @@ typedef enum _line_status_ {
     LINE_VALUE
 } line_status ;
 
+static const char * INI_NULL_STRING = "(null)";
+
 /*-------------------------------------------------------------------------*/
 /**
   @brief    Convert a string to lowercase.
@@ -420,8 +422,9 @@ const char * iniparser_getstring(const dictionary * d, const char * key, const c
         return def ;
 
     lc_key = strlwc(key, tmp_str, sizeof(tmp_str));
-    sval = dictionary_get(d, lc_key, def);
-    return sval ? sval : def ;
+    sval = dictionary_get(d, lc_key, INI_INVALID_KEY);
+    if (sval==INI_INVALID_KEY) return def ;
+    return sval ? sval : INI_NULL_STRING ;
 }
 
 /*-------------------------------------------------------------------------*/
@@ -456,7 +459,7 @@ long int iniparser_getlongint(const dictionary * d, const char * key, long int n
     const char * str ;
 
     str = iniparser_getstring(d, key, INI_INVALID_KEY);
-    if (str==INI_INVALID_KEY) return notfound ;
+    if (str==INI_INVALID_KEY || str==INI_NULL_STRING) return notfound ;
     return strtol(str, NULL, 0);
 }
 
@@ -511,7 +514,7 @@ double iniparser_getdouble(const dictionary * d, const char * key, double notfou
     const char * str ;
 
     str = iniparser_getstring(d, key, INI_INVALID_KEY);
-    if (str==INI_INVALID_KEY) return notfound ;
+    if (str==INI_INVALID_KEY || str==INI_NULL_STRING) return notfound ;
     return atof(str);
 }
 
@@ -553,7 +556,7 @@ int iniparser_getboolean(const dictionary * d, const char * key, int notfound)
     const char * c ;
 
     c = iniparser_getstring(d, key, INI_INVALID_KEY);
-    if (c==INI_INVALID_KEY) return notfound ;
+    if (c==INI_INVALID_KEY || c==INI_NULL_STRING) return notfound ;
     if (c[0]=='y' || c[0]=='Y' || c[0]=='1' || c[0]=='t' || c[0]=='T') {
         ret = 1 ;
     } else if (c[0]=='n' || c[0]=='N' || c[0]=='0' || c[0]=='f' || c[0]=='F') {

--- a/test/test_iniparser.c
+++ b/test/test_iniparser.c
@@ -645,13 +645,13 @@ void Test_dictionary_wrapper(CuTest *tc)
     CuAssertStrEquals(tc, "value", iniparser_getstring(dic, "section:key", NULL));
     /* reset the key's value*/
     CuAssertIntEquals(tc, 0, iniparser_set(dic, "section:key", NULL));
-    CuAssertStrEquals(tc, "dummy", iniparser_getstring(dic, "section:key", "dummy"));
+    CuAssertStrEquals(tc, "(null)", iniparser_getstring(dic, "section:key", "dummy"));
     CuAssertIntEquals(tc, 0, iniparser_set(dic, "section:key", "value"));
     CuAssertStrEquals(tc, "value", iniparser_getstring(dic, "section:key", NULL));
 
     iniparser_unset(dic, "section:key");
     CuAssertStrEquals(tc, "dummy", iniparser_getstring(dic, "section:key", "dummy"));
-    CuAssertStrEquals(tc, "dummy", iniparser_getstring(dic, "section", "dummy"));
+    CuAssertStrEquals(tc, "(null)", iniparser_getstring(dic, "section", "dummy"));
 
     CuAssertIntEquals(tc, 0, iniparser_set(dic, "section:key", NULL));
     CuAssertIntEquals(tc, 0, iniparser_set(dic, "section:key1", NULL));

--- a/test/test_iniparser.c
+++ b/test/test_iniparser.c
@@ -645,13 +645,13 @@ void Test_dictionary_wrapper(CuTest *tc)
     CuAssertStrEquals(tc, "value", iniparser_getstring(dic, "section:key", NULL));
     /* reset the key's value*/
     CuAssertIntEquals(tc, 0, iniparser_set(dic, "section:key", NULL));
-    CuAssertStrEquals(tc, NULL, iniparser_getstring(dic, "section:key", "dummy"));
+    CuAssertStrEquals(tc, "dummy", iniparser_getstring(dic, "section:key", "dummy"));
     CuAssertIntEquals(tc, 0, iniparser_set(dic, "section:key", "value"));
     CuAssertStrEquals(tc, "value", iniparser_getstring(dic, "section:key", NULL));
 
     iniparser_unset(dic, "section:key");
     CuAssertStrEquals(tc, "dummy", iniparser_getstring(dic, "section:key", "dummy"));
-    CuAssertStrEquals(tc, NULL, iniparser_getstring(dic, "section", "dummy"));
+    CuAssertStrEquals(tc, "dummy", iniparser_getstring(dic, "section", "dummy"));
 
     CuAssertIntEquals(tc, 0, iniparser_set(dic, "section:key", NULL));
     CuAssertIntEquals(tc, 0, iniparser_set(dic, "section:key1", NULL));


### PR DESCRIPTION
`iniparser_getboolean()` can segfault on malformed config files. #125
There are similar problem in `iniparser_getlongint()` and `iniparser_getdouble()`.

`iniparser_getstring()` returns `NULL` if there are section(not key) with that name.

The key does not exists, so it's better to return default fallback.
And returning `NULL` for "string" is not likely to be considered by programmers, which can be security problem.

Fixes #125