### PR TITLE
Fix warning about variadic macro

### DIFF
--- a/test/test_iniparser.c
+++ b/test/test_iniparser.c
@@ -16,8 +16,8 @@
 #define GOOD_INI_PATH "ressources/good_ini"
 #define BAD_INI_PATH "ressources/bad_ini"
 
-#define stringify_2(x...)     #x
-#define stringify(x...)       stringify_2(x)
+#define stringify_2(x)     #x
+#define stringify(x)       stringify_2(x)
 
 /* Tool function to create and populate a generic non-empty dictionary */
 static dictionary * generate_dictionary(unsigned sections, unsigned entries_per_section)


### PR DESCRIPTION
For some reason when built with -m32 gcc produces this warning:

test_iniparser.c:19:22: warning: ISO C does not permit named variadic macros [-Wvariadic-macros]
   19 | #define stringify_2(x...)     #x

For the limited use in this test there is no need for variadic stringify.

With this the warning is avoided, and the test passes on both 32bit and 64bit.