### PR TITLE
Free dictionaries in test_dictionary.c

### DIFF
--- a/test/test_dictionary.c
+++ b/test/test_dictionary.c
@@ -53,6 +53,7 @@ void Test_dictionary_grow(CuTest *tc)
         CuAssertIntEquals(tc, 0, dic->n);
         CuAssertIntEquals(tc, (1 << i) * DICTMINSZ, dic->size);
     }
+    dictionary_del(dic);
 }
 
 void Test_dictionary_hash(CuTest *tc)
@@ -184,6 +185,8 @@ void Test_dictionary_unset(CuTest *tc)
     CuAssertStrEquals(tc, dic1_dump, dic2_dump);
     free(dic1_dump);
     free(dic2_dump);
+    dictionary_del(dic1);
+    dictionary_del(dic2);
 }
 
 void Test_dictionary_dump(CuTest *tc)


### PR DESCRIPTION
Hi, I am a new contributor to this repository :). I came across the open issue #123  which is a leaksanitizer report about a leak that happens on make check. I was able to reproduce the bug on running make check and was able to generate a patch for it. The leak happens within functions `Test_dictionary_grow` and `Test_dictionary_unset`. In `Test_dictionary_grow`, the `dic` dictionary is allocated but not freed. Similarly, within `Test_dictionary_hash` the dictionaries `dic1` and `dic2` are allocated but not freed.

I have verified that after the patch, the leak no longer occurs through leaksanitizer (and there is no double free for that matter).

Please let me know if the patch is useful :)