### PR TITLE
Replace POSIX ssize_t with C standard size_t

### DIFF
--- a/example/iniexample.c
+++ b/example/iniexample.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #include "iniparser.h"
 

--- a/example/parse.c
+++ b/example/parse.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #include "iniparser.h"
 

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -18,7 +18,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 /** Minimal allocated number of entries in a dictionary */
 #define DICTMINSZ   128
@@ -170,7 +169,7 @@ dictionary * dictionary_new(size_t size)
 /*--------------------------------------------------------------------------*/
 void dictionary_del(dictionary * d)
 {
-    ssize_t  i ;
+    size_t  i ;
 
     if (d==NULL) return ;
     for (i=0 ; i<d->size ; i++) {
@@ -203,7 +202,7 @@ void dictionary_del(dictionary * d)
 const char * dictionary_get(const dictionary * d, const char * key, const char * def)
 {
     unsigned    hash ;
-    ssize_t      i ;
+    size_t      i ;
 
     hash = dictionary_hash(key);
     for (i=0 ; i<d->size ; i++) {
@@ -248,7 +247,7 @@ const char * dictionary_get(const dictionary * d, const char * key, const char *
 /*--------------------------------------------------------------------------*/
 int dictionary_set(dictionary * d, const char * key, const char * val)
 {
-    ssize_t         i ;
+    size_t         i ;
     unsigned       hash ;
 
     if (d==NULL || key==NULL) return -1 ;
@@ -308,7 +307,7 @@ int dictionary_set(dictionary * d, const char * key, const char * val)
 void dictionary_unset(dictionary * d, const char * key)
 {
     unsigned    hash ;
-    ssize_t      i ;
+    size_t      i ;
 
     if (key == NULL || d == NULL) {
         return;
@@ -356,7 +355,7 @@ void dictionary_unset(dictionary * d, const char * key)
 /*--------------------------------------------------------------------------*/
 void dictionary_dump(const dictionary * d, FILE * out)
 {
-    ssize_t  i ;
+    size_t  i ;
 
     if (d==NULL || out==NULL) return ;
     if (d->n<1) {

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -19,8 +19,6 @@
  ---------------------------------------------------------------------------*/
 
 #include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -42,7 +42,7 @@ extern "C" {
  */
 /*-------------------------------------------------------------------------*/
 typedef struct _dictionary_ {
-    int             n ;     /** Number of entries in dictionary */
+    unsigned        n ;     /** Number of entries in dictionary */
     size_t          size ;  /** Storage size */
     char        **  val ;   /** List of string values */
     char        **  key ;   /** List of string keys */

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -21,7 +21,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -44,7 +43,7 @@ extern "C" {
 /*-------------------------------------------------------------------------*/
 typedef struct _dictionary_ {
     int             n ;     /** Number of entries in dictionary */
-    ssize_t         size ;  /** Storage size */
+    size_t          size ;  /** Storage size */
     char        **  val ;   /** List of string values */
     char        **  key ;   /** List of string keys */
     unsigned     *  hash ;  /** List of hash values for keys */

--- a/src/iniparser.c
+++ b/src/iniparser.c
@@ -164,7 +164,7 @@ void iniparser_set_error_callback(int (*errback)(const char *, ...))
 /*--------------------------------------------------------------------------*/
 int iniparser_getnsec(const dictionary * d)
 {
-    int i ;
+    size_t i ;
     int nsec ;
 
     if (d==NULL) return -1 ;
@@ -195,7 +195,7 @@ int iniparser_getnsec(const dictionary * d)
 /*--------------------------------------------------------------------------*/
 const char * iniparser_getsecname(const dictionary * d, int n)
 {
-    int i ;
+    size_t i ;
     int foundsec ;
 
     if (d==NULL || n<0) return NULL ;
@@ -230,7 +230,7 @@ const char * iniparser_getsecname(const dictionary * d, int n)
 /*--------------------------------------------------------------------------*/
 void iniparser_dump(const dictionary * d, FILE * f)
 {
-    int     i ;
+    size_t i ;
 
     if (d==NULL || f==NULL) return ;
     for (i=0 ; i<d->size ; i++) {
@@ -258,8 +258,8 @@ void iniparser_dump(const dictionary * d, FILE * f)
 /*--------------------------------------------------------------------------*/
 void iniparser_dump_ini(const dictionary * d, FILE * f)
 {
-    int          i ;
-    int          nsec ;
+    size_t       i ;
+    size_t       nsec ;
     const char * secname ;
 
     if (d==NULL || f==NULL) return ;
@@ -296,7 +296,7 @@ void iniparser_dump_ini(const dictionary * d, FILE * f)
 /*--------------------------------------------------------------------------*/
 void iniparser_dumpsection_ini(const dictionary * d, const char * s, FILE * f)
 {
-    int     j ;
+    size_t  j ;
     char    keym[ASCIILINESZ+1];
     int     seclen ;
 
@@ -332,7 +332,7 @@ int iniparser_getsecnkeys(const dictionary * d, const char * s)
 {
     int     seclen, nkeys ;
     char    keym[ASCIILINESZ+1];
-    int j ;
+    size_t  j ;
 
     nkeys = 0;
 
@@ -372,13 +372,13 @@ int iniparser_getsecnkeys(const dictionary * d, const char * s)
 /*--------------------------------------------------------------------------*/
 const char ** iniparser_getseckeys(const dictionary * d, const char * s, const char ** keys)
 {
-    int i, j, seclen ;
+    size_t i, j, seclen ;
     char keym[ASCIILINESZ+1];
 
     if (d==NULL || keys==NULL) return NULL;
     if (! iniparser_find_entry(d, s)) return NULL;
 
-    seclen  = (int)strlen(s);
+    seclen  = strlen(s);
     strlwc(s, keym, sizeof(keym));
     keym[seclen] = ':';
 

--- a/src/iniparser.c
+++ b/src/iniparser.c
@@ -9,6 +9,8 @@
 /*---------------------------- Includes ------------------------------------*/
 #include <ctype.h>
 #include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
 #include <inttypes.h>
 #include "iniparser.h"
 

--- a/src/iniparser.h
+++ b/src/iniparser.h
@@ -14,18 +14,6 @@
                                 Includes
  ---------------------------------------------------------------------------*/
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <stdint.h>
-
-/*
- * The following #include is necessary on many Unixes but not Linux.
- * It is not needed for Windows platforms.
- * Uncomment it if needed.
- */
-/* #include <unistd.h> */
-
 #include "dictionary.h"
 
 #ifdef __cplusplus

--- a/test/test_iniparser.c
+++ b/test/test_iniparser.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
 #include <dirent.h>
-#include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <stdarg.h>


### PR DESCRIPTION
Related: #90

`ssize_t` is not part of C standard.

It's platform-dependent and causing portability issue.

There are no cases where ssize_t variables become less than 0, so it's safe to change it to size_t.
