### PR TITLE
Sections with brackets

### DIFF
--- a/src/iniparser.c
+++ b/src/iniparser.c
@@ -673,8 +673,11 @@ static line_status iniparser_line(
         /* Comment line */
         sta = LINE_COMMENT ;
     } else if (line[0]=='[' && line[len-1]==']') {
-        /* Section name */
-        sscanf(line, "[%[^]]", section);
+        /* Section name without opening square bracket */
+        sscanf(line, "[%s", section);
+        /* Section name without closing square bracket */
+        section[len] = '\0';
+        len--;
         strstrip(section);
         strlwc(section, section, len);
         sta = LINE_SECTION ;

--- a/test/test_iniparser.c
+++ b/test/test_iniparser.c
@@ -23,9 +23,7 @@
 #define MISFORMED_INI_PATH "ressources/misformed.ini"
 #define MISFORMED_INI_SEC0 "[12345"
 #define MISFORMED_INI_SEC1 "12345]"
-#define MISFORMED_INI_SEC1_ "12345"
 #define MISFORMED_INI_SEC2 "123]45"
-#define MISFORMED_INI_SEC2_ "123"
 #define MISFORMED_INI_ATTR "1111"
 
 #define stringify_2(x)     #x
@@ -1136,24 +1134,8 @@ void Test_iniparser_misformed(CuTest *tc)
         return;
     }
 
-    /*
-     * This test proofs an inconsistency in iniparser_set():
-     *
-     * The section "12345]" (MISFORMED_INI_SEC1) is readable from dictionary
-     * directly after iniparser_set().
-     *
-     * The section is also written to file by iniparser_dump_ini() as
-     * "[12345]]" ("[" MISFOREMD_INI_SEC1 "]").
-     *
-     * But if the file is parsed by iniparser_load() it is read as "12345"
-     * (MISFORMED_INI_SEC).
-     *
-     * The reason is that iniparser_load() considers a section name to be
-     * enclosed by "[" and "]". If it find a line enclosed by square brackets
-     * it takes the characters enclosed by and excluding those brackets
-     */
     CuAssertIntEquals(tc, 2222, iniparser_getint(dic,
-                      MISFORMED_INI_SEC1_ ":" MISFORMED_INI_ATTR, -1));
+                      MISFORMED_INI_SEC1 ":" MISFORMED_INI_ATTR, -1));
     dictionary_del(dic);
     ret = remove(MISFORMED_INI_PATH);
 
@@ -1200,14 +1182,8 @@ void Test_iniparser_misformed(CuTest *tc)
         return;
     }
 
-    /*
-     * This test again proofs the inconsistency in iniparser_set() explained
-     * above.
-     *
-     * This time the section name is "123]45" (MISFORMED_INI_SEC2).
-     */
     CuAssertIntEquals(tc, 2222, iniparser_getint(dic,
-                      MISFORMED_INI_SEC2_ ":" MISFORMED_INI_ATTR, -1));
+                      MISFORMED_INI_SEC2 ":" MISFORMED_INI_ATTR, -1));
 del_dic:
     dictionary_del(dic);
 rm_ini:

--- a/test/test_iniparser.c
+++ b/test/test_iniparser.c
@@ -20,6 +20,13 @@
 #define TEST_TXT_PATH "ressources/test.txt"
 #define GRUEZI_INI_PATH "ressources/gruezi.ini"
 #define UTF8_INI_PATH "ressources/utf8.ini"
+#define MISFORMED_INI_PATH "ressources/misformed.ini"
+#define MISFORMED_INI_SEC0 "[12345"
+#define MISFORMED_INI_SEC1 "12345]"
+#define MISFORMED_INI_SEC1_ "12345"
+#define MISFORMED_INI_SEC2 "123]45"
+#define MISFORMED_INI_SEC2_ "123"
+#define MISFORMED_INI_ATTR "1111"
 
 #define stringify_2(x)     #x
 #define stringify(x)       stringify_2(x)
@@ -1023,4 +1030,191 @@ void Test_iniparser_utf8(CuTest *tc)
     CuAssertStrEquals(tc, "そうだね",
                       iniparser_getstring(dic, "拉麺:メンマ", NULL));
     dictionary_del(dic);
+}
+
+static void create_empty_ini_file(const char *filename)
+{
+    FILE *ini;
+
+    if ((ini = fopen(filename, "w")) == NULL) {
+        fprintf(stderr, "iniparser: cannot create %s\n", filename);
+        return;
+    }
+
+    fclose(ini);
+}
+
+void Test_iniparser_misformed(CuTest *tc)
+{
+    dictionary *dic;
+    FILE *ini;
+    int ret;
+
+    create_empty_ini_file(MISFORMED_INI_PATH);
+    dic = iniparser_load(MISFORMED_INI_PATH);
+
+    if (!dic) {
+        fprintf(stderr, "cannot parse file: %s\n", MISFORMED_INI_PATH);
+        return;
+    }
+
+    ret = iniparser_set(dic, MISFORMED_INI_SEC0, NULL);
+
+    if (ret < 0) {
+        fprintf(stderr, "cannot set section %s in: %s\n", MISFORMED_INI_SEC0,
+                MISFORMED_INI_PATH);
+        goto del_dic;
+    }
+
+    iniparser_set(dic, MISFORMED_INI_SEC0 ":" MISFORMED_INI_ATTR, "2222");
+    /* test dictionary */
+    CuAssertIntEquals(tc, 2222, iniparser_getint(dic,
+                      MISFORMED_INI_SEC0 ":" MISFORMED_INI_ATTR, -1));
+    ini = fopen(MISFORMED_INI_PATH, "w+");
+
+    if (!ini) {
+        fprintf(stderr, "iniparser: cannot open %s\n", MISFORMED_INI_PATH);
+        goto del_dic;
+    }
+
+    iniparser_dump_ini(dic, ini);
+    fclose(ini);
+    dictionary_del(dic);
+    /* check if section has been written as expected */
+    dic = iniparser_load(MISFORMED_INI_PATH);
+
+    if (!dic) {
+        fprintf(stderr, "cannot parse file: %s\n", MISFORMED_INI_PATH);
+        goto rm_ini;
+    }
+
+    CuAssertIntEquals(tc, 2222, iniparser_getint(dic,
+                      MISFORMED_INI_SEC0 ":" MISFORMED_INI_ATTR, -1));
+    dictionary_del(dic);
+    ret = remove(MISFORMED_INI_PATH);
+
+    if (ret) {
+        fprintf(stderr, "cannot remove file: %s\n", MISFORMED_INI_PATH);
+        return;
+    }
+
+    create_empty_ini_file(MISFORMED_INI_PATH);
+    dic = iniparser_load(MISFORMED_INI_PATH);
+
+    if (!dic) {
+        fprintf(stderr, "cannot parse file: %s\n", MISFORMED_INI_PATH);
+        return;
+    }
+
+    ret = iniparser_set(dic, MISFORMED_INI_SEC1, NULL);
+
+    if (ret < 0) {
+        fprintf(stderr, "cannot set section %s in: %s\n", MISFORMED_INI_SEC1,
+                MISFORMED_INI_PATH);
+        goto del_dic;
+    }
+
+    iniparser_set(dic, MISFORMED_INI_SEC1 ":" MISFORMED_INI_ATTR, "2222");
+    /* test dictionary */
+    CuAssertIntEquals(tc, 2222, iniparser_getint(dic,
+                      MISFORMED_INI_SEC1 ":" MISFORMED_INI_ATTR, -1));
+    ini = fopen(MISFORMED_INI_PATH, "w+");
+
+    if (!ini) {
+        fprintf(stderr, "iniparser: cannot open %s\n", MISFORMED_INI_PATH);
+        goto del_dic;
+    }
+
+    iniparser_dump_ini(dic, ini);
+    fclose(ini);
+    dictionary_del(dic);
+    /* check if section has been written as expected */
+    dic = iniparser_load(MISFORMED_INI_PATH);
+
+    if (!dic) {
+        fprintf(stderr, "cannot parse file: %s\n", MISFORMED_INI_PATH);
+        return;
+    }
+
+    /*
+     * This test proofs an inconsistency in iniparser_set():
+     *
+     * The section "12345]" (MISFORMED_INI_SEC1) is readable from dictionary
+     * directly after iniparser_set().
+     *
+     * The section is also written to file by iniparser_dump_ini() as
+     * "[12345]]" ("[" MISFOREMD_INI_SEC1 "]").
+     *
+     * But if the file is parsed by iniparser_load() it is read as "12345"
+     * (MISFORMED_INI_SEC).
+     *
+     * The reason is that iniparser_load() considers a section name to be
+     * enclosed by "[" and "]". If it find a line enclosed by square brackets
+     * it takes the characters enclosed by and excluding those brackets
+     */
+    CuAssertIntEquals(tc, 2222, iniparser_getint(dic,
+                      MISFORMED_INI_SEC1_ ":" MISFORMED_INI_ATTR, -1));
+    dictionary_del(dic);
+    ret = remove(MISFORMED_INI_PATH);
+
+    if (ret) {
+        fprintf(stderr, "cannot remove file: %s\n", MISFORMED_INI_PATH);
+        return;
+    }
+
+    create_empty_ini_file(MISFORMED_INI_PATH);
+    dic = iniparser_load(MISFORMED_INI_PATH);
+
+    if (!dic) {
+        fprintf(stderr, "cannot parse file: %s\n", MISFORMED_INI_PATH);
+        return;
+    }
+
+    ret = iniparser_set(dic, MISFORMED_INI_SEC2, NULL);
+
+    if (ret < 0) {
+        fprintf(stderr, "cannot set section %s in: %s\n", MISFORMED_INI_SEC2,
+                MISFORMED_INI_PATH);
+        goto del_dic;
+    }
+
+    iniparser_set(dic, MISFORMED_INI_SEC2 ":" MISFORMED_INI_ATTR, "2222");
+    /* test dictionary */
+    CuAssertIntEquals(tc, 2222, iniparser_getint(dic,
+                      MISFORMED_INI_SEC2 ":" MISFORMED_INI_ATTR, -1));
+    ini = fopen(MISFORMED_INI_PATH, "w+");
+
+    if (!ini) {
+        fprintf(stderr, "iniparser: cannot open %s\n", MISFORMED_INI_PATH);
+        goto del_dic;
+    }
+
+    iniparser_dump_ini(dic, ini);
+    fclose(ini);
+    dictionary_del(dic);
+    /* check if section has been written as expected */
+    dic = iniparser_load(MISFORMED_INI_PATH);
+
+    if (!dic) {
+        fprintf(stderr, "cannot parse file: %s\n", MISFORMED_INI_PATH);
+        return;
+    }
+
+    /*
+     * This test again proofs the inconsistency in iniparser_set() explained
+     * above.
+     *
+     * This time the section name is "123]45" (MISFORMED_INI_SEC2).
+     */
+    CuAssertIntEquals(tc, 2222, iniparser_getint(dic,
+                      MISFORMED_INI_SEC2_ ":" MISFORMED_INI_ATTR, -1));
+del_dic:
+    dictionary_del(dic);
+rm_ini:
+    ret = remove(MISFORMED_INI_PATH);
+
+    if (ret) {
+        fprintf(stderr, "cannot remove file: %s\n", MISFORMED_INI_PATH);
+        return;
+    }
 }

--- a/test/test_iniparser.c
+++ b/test/test_iniparser.c
@@ -20,12 +20,11 @@
 #define TEST_TXT_PATH "ressources/test.txt"
 #define GRUEZI_INI_PATH "ressources/gruezi.ini"
 #define UTF8_INI_PATH "ressources/utf8.ini"
-#define MISFORMED_INI_PATH "ressources/misformed.ini"
+#define TMP_INI_PATH "ressources/tmp.ini"
 #define MISFORMED_INI_SEC0 "[12345"
 #define MISFORMED_INI_SEC1 "12345]"
 #define MISFORMED_INI_SEC2 "123]45"
 #define MISFORMED_INI_ATTR "1111"
-#define TMP_INI_PATH "ressources/tmp.ini"
 #define QUOTES_INI_PATH "ressources/quotes.ini"
 #define QUOTES_INI_SEC "quotes"
 #define QUOTES_INI_ATTR0 "string0"
@@ -1060,11 +1059,11 @@ void Test_iniparser_misformed(CuTest *tc)
     FILE *ini;
     int ret;
 
-    create_empty_ini_file(MISFORMED_INI_PATH);
-    dic = iniparser_load(MISFORMED_INI_PATH);
+    create_empty_ini_file(TMP_INI_PATH);
+    dic = iniparser_load(TMP_INI_PATH);
 
     if (!dic) {
-        fprintf(stderr, "cannot parse file: %s\n", MISFORMED_INI_PATH);
+        fprintf(stderr, "cannot parse file: %s\n", TMP_INI_PATH);
         return;
     }
 
@@ -1072,7 +1071,7 @@ void Test_iniparser_misformed(CuTest *tc)
 
     if (ret < 0) {
         fprintf(stderr, "cannot set section %s in: %s\n", MISFORMED_INI_SEC0,
-                MISFORMED_INI_PATH);
+                TMP_INI_PATH);
         goto del_dic;
     }
 
@@ -1080,10 +1079,10 @@ void Test_iniparser_misformed(CuTest *tc)
     /* test dictionary */
     CuAssertIntEquals(tc, 2222, iniparser_getint(dic,
                       MISFORMED_INI_SEC0 ":" MISFORMED_INI_ATTR, -1));
-    ini = fopen(MISFORMED_INI_PATH, "w+");
+    ini = fopen(TMP_INI_PATH, "w+");
 
     if (!ini) {
-        fprintf(stderr, "iniparser: cannot open %s\n", MISFORMED_INI_PATH);
+        fprintf(stderr, "iniparser: cannot open %s\n", TMP_INI_PATH);
         goto del_dic;
     }
 
@@ -1091,28 +1090,28 @@ void Test_iniparser_misformed(CuTest *tc)
     fclose(ini);
     dictionary_del(dic);
     /* check if section has been written as expected */
-    dic = iniparser_load(MISFORMED_INI_PATH);
+    dic = iniparser_load(TMP_INI_PATH);
 
     if (!dic) {
-        fprintf(stderr, "cannot parse file: %s\n", MISFORMED_INI_PATH);
+        fprintf(stderr, "cannot parse file: %s\n", TMP_INI_PATH);
         goto rm_ini;
     }
 
     CuAssertIntEquals(tc, 2222, iniparser_getint(dic,
                       MISFORMED_INI_SEC0 ":" MISFORMED_INI_ATTR, -1));
     dictionary_del(dic);
-    ret = remove(MISFORMED_INI_PATH);
+    ret = remove(TMP_INI_PATH);
 
     if (ret) {
-        fprintf(stderr, "cannot remove file: %s\n", MISFORMED_INI_PATH);
+        fprintf(stderr, "cannot remove file: %s\n", TMP_INI_PATH);
         return;
     }
 
-    create_empty_ini_file(MISFORMED_INI_PATH);
-    dic = iniparser_load(MISFORMED_INI_PATH);
+    create_empty_ini_file(TMP_INI_PATH);
+    dic = iniparser_load(TMP_INI_PATH);
 
     if (!dic) {
-        fprintf(stderr, "cannot parse file: %s\n", MISFORMED_INI_PATH);
+        fprintf(stderr, "cannot parse file: %s\n", TMP_INI_PATH);
         return;
     }
 
@@ -1120,7 +1119,7 @@ void Test_iniparser_misformed(CuTest *tc)
 
     if (ret < 0) {
         fprintf(stderr, "cannot set section %s in: %s\n", MISFORMED_INI_SEC1,
-                MISFORMED_INI_PATH);
+                TMP_INI_PATH);
         goto del_dic;
     }
 
@@ -1128,10 +1127,10 @@ void Test_iniparser_misformed(CuTest *tc)
     /* test dictionary */
     CuAssertIntEquals(tc, 2222, iniparser_getint(dic,
                       MISFORMED_INI_SEC1 ":" MISFORMED_INI_ATTR, -1));
-    ini = fopen(MISFORMED_INI_PATH, "w+");
+    ini = fopen(TMP_INI_PATH, "w+");
 
     if (!ini) {
-        fprintf(stderr, "iniparser: cannot open %s\n", MISFORMED_INI_PATH);
+        fprintf(stderr, "iniparser: cannot open %s\n", TMP_INI_PATH);
         goto del_dic;
     }
 
@@ -1139,28 +1138,28 @@ void Test_iniparser_misformed(CuTest *tc)
     fclose(ini);
     dictionary_del(dic);
     /* check if section has been written as expected */
-    dic = iniparser_load(MISFORMED_INI_PATH);
+    dic = iniparser_load(TMP_INI_PATH);
 
     if (!dic) {
-        fprintf(stderr, "cannot parse file: %s\n", MISFORMED_INI_PATH);
+        fprintf(stderr, "cannot parse file: %s\n", TMP_INI_PATH);
         return;
     }
 
     CuAssertIntEquals(tc, 2222, iniparser_getint(dic,
                       MISFORMED_INI_SEC1 ":" MISFORMED_INI_ATTR, -1));
     dictionary_del(dic);
-    ret = remove(MISFORMED_INI_PATH);
+    ret = remove(TMP_INI_PATH);
 
     if (ret) {
-        fprintf(stderr, "cannot remove file: %s\n", MISFORMED_INI_PATH);
+        fprintf(stderr, "cannot remove file: %s\n", TMP_INI_PATH);
         return;
     }
 
-    create_empty_ini_file(MISFORMED_INI_PATH);
-    dic = iniparser_load(MISFORMED_INI_PATH);
+    create_empty_ini_file(TMP_INI_PATH);
+    dic = iniparser_load(TMP_INI_PATH);
 
     if (!dic) {
-        fprintf(stderr, "cannot parse file: %s\n", MISFORMED_INI_PATH);
+        fprintf(stderr, "cannot parse file: %s\n", TMP_INI_PATH);
         return;
     }
 
@@ -1168,7 +1167,7 @@ void Test_iniparser_misformed(CuTest *tc)
 
     if (ret < 0) {
         fprintf(stderr, "cannot set section %s in: %s\n", MISFORMED_INI_SEC2,
-                MISFORMED_INI_PATH);
+                TMP_INI_PATH);
         goto del_dic;
     }
 
@@ -1176,10 +1175,10 @@ void Test_iniparser_misformed(CuTest *tc)
     /* test dictionary */
     CuAssertIntEquals(tc, 2222, iniparser_getint(dic,
                       MISFORMED_INI_SEC2 ":" MISFORMED_INI_ATTR, -1));
-    ini = fopen(MISFORMED_INI_PATH, "w+");
+    ini = fopen(TMP_INI_PATH, "w+");
 
     if (!ini) {
-        fprintf(stderr, "iniparser: cannot open %s\n", MISFORMED_INI_PATH);
+        fprintf(stderr, "iniparser: cannot open %s\n", TMP_INI_PATH);
         goto del_dic;
     }
 
@@ -1187,10 +1186,10 @@ void Test_iniparser_misformed(CuTest *tc)
     fclose(ini);
     dictionary_del(dic);
     /* check if section has been written as expected */
-    dic = iniparser_load(MISFORMED_INI_PATH);
+    dic = iniparser_load(TMP_INI_PATH);
 
     if (!dic) {
-        fprintf(stderr, "cannot parse file: %s\n", MISFORMED_INI_PATH);
+        fprintf(stderr, "cannot parse file: %s\n", TMP_INI_PATH);
         return;
     }
 
@@ -1199,10 +1198,10 @@ void Test_iniparser_misformed(CuTest *tc)
 del_dic:
     dictionary_del(dic);
 rm_ini:
-    ret = remove(MISFORMED_INI_PATH);
+    ret = remove(TMP_INI_PATH);
 
     if (ret) {
-        fprintf(stderr, "cannot remove file: %s\n", MISFORMED_INI_PATH);
+        fprintf(stderr, "cannot remove file: %s\n", TMP_INI_PATH);
         return;
     }
 }


### PR DESCRIPTION
This will fix #147.

@ndevilla 
Please have a look at the issue which is explained in #147 and in the first commit of this PR.

This PR changes the behavior of iniparser to accept closing square brackets within section names.