### PR TITLE
Quote and escape

### DIFF
--- a/src/iniparser.h
+++ b/src/iniparser.h
@@ -82,6 +82,13 @@ const char * iniparser_getsecname(const dictionary * d, int n);
 
   This function dumps a given dictionary into a loadable ini file.
   It is Ok to specify @c stderr or @c stdout as output files.
+
+  All values are quoted these charecters are escaped:
+
+  ” - the quote character (e.g. “String with ”Quotes””)
+
+  \ - the backslash character (e.g. “C:\tmp”)
+
  */
 /*--------------------------------------------------------------------------*/
 
@@ -381,6 +388,17 @@ int iniparser_find_entry(const dictionary * ini, const char * entry) ;
   the name of the file to be read. It returns a dictionary object that
   should not be accessed directly, but through accessor functions
   instead.
+
+  Iff the value is a quoted string it supports some escape sequences:
+
+  ” - the quote character (e.g. “String with ”Quotes””)
+
+  \ - the backslash character (e.g. “C:\tmp”)
+
+  Escape sequences always start with a backslash. Additional escape sequences
+  might be added in the future. Backslash characters must be escaped. Any other
+  sequence then those outlined above is invalid and may lead to unpredictable
+  results.
 
   The returned dictionary must be freed using iniparser_freedict().
  */

--- a/test/ressources/quotes.ini
+++ b/test/ressources/quotes.ini
@@ -2,3 +2,6 @@
 string0="str\"ing"
 string1="str;ing"
 string2="str#ing"
+string3=str"ing
+string4=str;ing
+string5=str#ing

--- a/test/ressources/quotes.ini
+++ b/test/ressources/quotes.ini
@@ -1,0 +1,4 @@
+[quotes]
+string0="str\"ing"
+string1="str;ing"
+string2="str#ing"

--- a/test/ressources/quotes.ini
+++ b/test/ressources/quotes.ini
@@ -5,3 +5,7 @@ string2="str#ing"
 string3=str"ing
 string4=str;ing
 string5=str#ing
+str"ing="str\"ing"
+"str;ing"="str;ing"
+"str#ing"="str#ing"
+str:ing="str\"ing"

--- a/test/test_iniparser.c
+++ b/test/test_iniparser.c
@@ -1055,6 +1055,9 @@ void Test_iniparser_quotes(CuTest *tc)
     FILE *ini;
     int ret;
 
+    /**
+     * Test iniparser_load()
+     */
     /* check if section has been written as expected */
     dic = iniparser_load(QUOTES_INI_PATH);
 
@@ -1084,7 +1087,24 @@ void Test_iniparser_quotes(CuTest *tc)
     CuAssertStrEquals(tc, "str", iniparser_getstring(dic,
                       QUOTES_INI_SEC ":" QUOTES_INI_ATTR5, NULL));
     /*
-     * test escaping
+     * iniparser_load() supports quotes in attributes
+     */
+    CuAssertStrEquals(tc, "str\\", iniparser_getstring(dic,
+                      QUOTES_INI_SEC ":" "str\"ing", NULL));
+    /*
+     * iniparser_load() does not support semicolon or hash in attributes
+     */
+    CuAssertStrEquals(tc, NULL, iniparser_getstring(dic,
+                      QUOTES_INI_SEC ":" "str;ing", NULL));
+    CuAssertStrEquals(tc, NULL, iniparser_getstring(dic,
+                      QUOTES_INI_SEC ":" "str#ing", NULL));
+    /*
+     * iniparser_load() does support colon in attributes
+     */
+    CuAssertStrEquals(tc, "str\\", iniparser_getstring(dic,
+                      QUOTES_INI_SEC ":" "str:ing", NULL));
+    /**
+     * test iniparser_set()
      */
     create_empty_ini_file(TMP_INI_PATH);
     dic = iniparser_load(TMP_INI_PATH);

--- a/test/test_iniparser.c
+++ b/test/test_iniparser.c
@@ -1066,11 +1066,7 @@ void Test_iniparser_quotes(CuTest *tc)
         goto rm_ini;
     }
 
-    /*
-     * iniparser_load() does not support escaped quotes in values if they are
-     * quoted
-     */
-    CuAssertStrEquals(tc, "str\\", iniparser_getstring(dic,
+    CuAssertStrEquals(tc, QUOTES_INI_VAL0, iniparser_getstring(dic,
                       QUOTES_INI_SEC ":" QUOTES_INI_ATTR0, NULL));
     /*
      * iniparser_load() supports semicolon and hash in values if they are
@@ -1089,7 +1085,7 @@ void Test_iniparser_quotes(CuTest *tc)
     /*
      * iniparser_load() supports quotes in attributes
      */
-    CuAssertStrEquals(tc, "str\\", iniparser_getstring(dic,
+    CuAssertStrEquals(tc, QUOTES_INI_VAL0, iniparser_getstring(dic,
                       QUOTES_INI_SEC ":" "str\"ing", NULL));
     /*
      * iniparser_load() does not support semicolon or hash in attributes
@@ -1101,8 +1097,50 @@ void Test_iniparser_quotes(CuTest *tc)
     /*
      * iniparser_load() does support colon in attributes
      */
-    CuAssertStrEquals(tc, "str\\", iniparser_getstring(dic,
+    CuAssertStrEquals(tc, QUOTES_INI_VAL0, iniparser_getstring(dic,
                       QUOTES_INI_SEC ":" "str:ing", NULL));
+    ini = fopen(TMP_INI_PATH, "w+");
+
+    if (!ini) {
+        fprintf(stderr, "iniparser: cannot open %s\n", TMP_INI_PATH);
+        goto del_dic;
+    }
+
+    /**
+     * Test iniparser_dump_ini()
+     */
+    iniparser_dump_ini(dic, ini);
+    fclose(ini);
+    dictionary_del(dic);
+    dic = iniparser_load(TMP_INI_PATH);
+
+    CuAssertStrEquals(tc, QUOTES_INI_VAL0, iniparser_getstring(dic,
+                      QUOTES_INI_SEC ":" QUOTES_INI_ATTR0, NULL));
+    CuAssertStrEquals(tc, QUOTES_INI_VAL1, iniparser_getstring(dic,
+                      QUOTES_INI_SEC ":" QUOTES_INI_ATTR1, NULL));
+    CuAssertStrEquals(tc, QUOTES_INI_VAL2, iniparser_getstring(dic,
+                      QUOTES_INI_SEC ":" QUOTES_INI_ATTR2, NULL));
+    CuAssertStrEquals(tc, QUOTES_INI_VAL0, iniparser_getstring(dic,
+                      QUOTES_INI_SEC ":" QUOTES_INI_ATTR3, NULL));
+    CuAssertStrEquals(tc, "str", iniparser_getstring(dic,
+                      QUOTES_INI_SEC ":" QUOTES_INI_ATTR4, NULL));
+    CuAssertStrEquals(tc, "str", iniparser_getstring(dic,
+                      QUOTES_INI_SEC ":" QUOTES_INI_ATTR5, NULL));
+    CuAssertStrEquals(tc, QUOTES_INI_VAL0, iniparser_getstring(dic,
+                      QUOTES_INI_SEC ":" "str\"ing", NULL));
+    CuAssertStrEquals(tc, NULL, iniparser_getstring(dic,
+                      QUOTES_INI_SEC ":" "str;ing", NULL));
+    CuAssertStrEquals(tc, NULL, iniparser_getstring(dic,
+                      QUOTES_INI_SEC ":" "str#ing", NULL));
+    CuAssertStrEquals(tc, QUOTES_INI_VAL0, iniparser_getstring(dic,
+                      QUOTES_INI_SEC ":" "str:ing", NULL));
+    dictionary_del(dic);
+    ret = remove(TMP_INI_PATH);
+
+    if (ret) {
+        fprintf(stderr, "cannot remove file: %s\n", TMP_INI_PATH);
+        return;
+    }
     /**
      * test iniparser_set()
      */
@@ -1197,8 +1235,7 @@ void Test_iniparser_quotes(CuTest *tc)
         goto rm_ini;
     }
 
-    /* iniparser_load() does not support ; in values */
-    CuAssertStrEquals(tc, "str", iniparser_getstring(dic,
+    CuAssertStrEquals(tc, QUOTES_INI_VAL1, iniparser_getstring(dic,
                       QUOTES_INI_SEC ":" QUOTES_INI_ATTR1, NULL));
     dictionary_del(dic);
     ret = remove(TMP_INI_PATH);
@@ -1250,8 +1287,7 @@ void Test_iniparser_quotes(CuTest *tc)
         goto rm_ini;
     }
 
-    /* iniparser_load() does not support ; in values */
-    CuAssertStrEquals(tc, "str", iniparser_getstring(dic,
+    CuAssertStrEquals(tc, QUOTES_INI_VAL2, iniparser_getstring(dic,
                       QUOTES_INI_SEC ":" QUOTES_INI_ATTR2, NULL));
 del_dic:
     dictionary_del(dic);

--- a/test/test_iniparser.c
+++ b/test/test_iniparser.c
@@ -26,6 +26,9 @@
 #define QUOTES_INI_ATTR0 "string0"
 #define QUOTES_INI_ATTR1 "string1"
 #define QUOTES_INI_ATTR2 "string2"
+#define QUOTES_INI_ATTR3 "string3"
+#define QUOTES_INI_ATTR4 "string4"
+#define QUOTES_INI_ATTR5 "string5"
 #define QUOTES_INI_VAL0 "str\"ing"
 #define QUOTES_INI_VAL1 "str;ing"
 #define QUOTES_INI_VAL2 "str#ing"
@@ -1060,13 +1063,26 @@ void Test_iniparser_quotes(CuTest *tc)
         goto rm_ini;
     }
 
-    /* iniparser_load() does not support escaping quotes in INI files */
+    /*
+     * iniparser_load() does not support escaped quotes in values if they are
+     * quoted
+     */
     CuAssertStrEquals(tc, "str\\", iniparser_getstring(dic,
                       QUOTES_INI_SEC ":" QUOTES_INI_ATTR0, NULL));
+    /*
+     * iniparser_load() supports semicolon and hash in values if they are
+     * quoted
+     */
     CuAssertStrEquals(tc, QUOTES_INI_VAL1, iniparser_getstring(dic,
                       QUOTES_INI_SEC ":" QUOTES_INI_ATTR1, NULL));
     CuAssertStrEquals(tc, QUOTES_INI_VAL2, iniparser_getstring(dic,
                       QUOTES_INI_SEC ":" QUOTES_INI_ATTR2, NULL));
+    CuAssertStrEquals(tc, QUOTES_INI_VAL0, iniparser_getstring(dic,
+                      QUOTES_INI_SEC ":" QUOTES_INI_ATTR3, NULL));
+    CuAssertStrEquals(tc, "str", iniparser_getstring(dic,
+                      QUOTES_INI_SEC ":" QUOTES_INI_ATTR4, NULL));
+    CuAssertStrEquals(tc, "str", iniparser_getstring(dic,
+                      QUOTES_INI_SEC ":" QUOTES_INI_ATTR5, NULL));
     /*
      * test escaping
      */


### PR DESCRIPTION
The issue is:

- `iniparser_load()` did not support escaped quotes in quoted values
  - `"str\"ing"` => `str\`

However:

- `iniparser_set()` supports escaped quotes in values
  - `"str\"ing"` => `str"ing`
- `iniparser_load()` supports quotes in unquoted values
  - `str"ing` => `str"ing`

Additionally:

- `iniparser_load()` does not support semicolon and hash in unquoted values
  - `str;ing` => `str`
  - `str#ing` => `str`

...which is correct, because they denote the start of a comment.

However:

- `iniparser_load()` supports semicolon and hash in quoted values
  - `"str;ing"` => `str;ing`
  - `"str#ing"` => `str#ing`
- `iniparser_set()` supports semicolon and hash in values
  - `"str\"ing"` => `str"ing`
  - `"str;ing"` => `str;ing`
  - `"str#ing"` => `str#ing`

But:

- `iniparser_dump_ini()` writes all values without quotes

So if dictionary contained values containing quotes, semicolon or hash, dumping
the dictionary to INI file and loading this file broke those values.

This pull request fixes this:

1) `iniparser_load()` will support escaping iff value is quoted
2) `iniparser_dump_ini()` will quote all values and escape `'` and `"`

These changes do not break existing tests and do not change the behavior of
iniparser in a backward incompatible way.

This fixes #97