### PR TITLE
Add Clusterfuzzlite integration

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,8 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool cmake \
+                      pkg-config curl check
+COPY . $SRC/iniparser
+COPY .clusterfuzzlite/build.sh $SRC/build.sh
+COPY .clusterfuzzlite/*.cpp $SRC/
+COPY .clusterfuzzlite/*.c $SRC/
+WORKDIR iniparser

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -2,8 +2,9 @@
 find . -name "*.c" -exec $CC $CFLAGS -I./src -c {} \;
 find . -name "*.o" -exec cp {} . \;
 
-rm -f ./test*.o
 llvm-ar rcs libfuzz.a *.o
 
 
-$CC $CFLAGS $LIB_FUZZING_ENGINE $SRC/fuzzer.c -Wl,--whole-archive $SRC/iniparser/libfuzz.a -Wl,--allow-multiple-definition -I$SRC/iniparser/src  -o $OUT/fuzzer
+$CC $CFLAGS $LIB_FUZZING_ENGINE $SRC/fuzzer.c \
+  -Wl,--whole-archive $SRC/iniparser/libfuzz.a -Wl,--allow-multiple-definition \
+  -I$SRC/iniparser/src  -o $OUT/fuzzer

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+find . -name "*.c" -exec $CC $CFLAGS -I./src -c {} \;
+find . -name "*.o" -exec cp {} . \;
+
+rm -f ./test*.o
+llvm-ar rcs libfuzz.a *.o
+
+
+$CC $CFLAGS $LIB_FUZZING_ENGINE $SRC/fuzzer.c -Wl,--whole-archive $SRC/iniparser/libfuzz.a -Wl,--allow-multiple-definition -I$SRC/iniparser/src  -o $OUT/fuzzer

--- a/.clusterfuzzlite/fuzzer.c
+++ b/.clusterfuzzlite/fuzzer.c
@@ -1,8 +1,3 @@
-#include <stdlib.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/.clusterfuzzlite/fuzzer.c
+++ b/.clusterfuzzlite/fuzzer.c
@@ -1,0 +1,36 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "dictionary.h"
+#include "iniparser.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    // Create a temporary file with the fuzzed data
+    FILE *temp_file = tmpfile();
+    if (temp_file == NULL) {
+        return 0;
+    }
+
+    // Write the fuzzed data to the temporary file
+    fwrite(data, 1, size, temp_file);
+    fseek(temp_file, 0, SEEK_SET);
+
+    // Call the target function with the temporary file and a dummy filename
+    const char dummy_filename[] = "dummy.ini";
+    dictionary *result = iniparser_load_file(temp_file, dummy_filename);
+
+    // Cleanup
+    if (result != NULL) {
+        dictionary_del(result);
+    }
+    fclose(temp_file);
+
+    return 0;
+}
+  

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,30 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ master ]
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: c++
+        bad-build-check: false
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 100
+        mode: 'code-change'
+        report-unreproducible-crashes: false
+        sanitizer: ${{ matrix.sanitizer }}


### PR DESCRIPTION
This adds fuzzing by way of [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/), which is a GitHub action that will perform a short amount of fuzzing for new PRs. The goal is to use fuzzing to catch bugs that may be introduced by new PRs.

If you'd like to test this the way ClusterFuzzLite runs it (by way of OSS-Fuzz) you can use the steps:

```sh
git clone https://github.com/google/oss-fuzz
git clone https://github.com/DavidKorczynski/iniparser
cd iniparser
git checkout cflite

# Build the fuzzers in .clusterfuzzlite
python3 ../oss-fuzz/infra/helper.py build_fuzzers --external $PWD

# Run the fuzzer for 10 seconds
python3 ../oss-fuzz/infra/helper.py run_fuzzer --external $PWD fuzzer -- -max_total_time=10
```