### PR TITLE
cmake: use CMAKE_INSTALL_FULL_* in the pc file

### DIFF
--- a/cmake/pc.in
+++ b/cmake/pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=${prefix}
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/@PROJECT_NAME@
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+exec_prefix=@CMAKE_INSTALL_FULL_LIBEXECDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@/@PROJECT_NAME@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 
 Name: @PROJECT_NAME@
 Description: Simple C library offering ini file parsing services


### PR DESCRIPTION
This makes possible to use absolute paths in `CMAKE_INSTALL_LIBDIR`. The current situation can causes troubles in some environment notably nixpkgs/NixOS.

See https://github.com/jtojnar/cmake-snips?tab=readme-ov-file#assuming-cmake_install_dir-is-relative-path for more details.